### PR TITLE
Update CHANGELOG.md to link to tagged versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Nothing here yet.
 
-## v0.4.4
+## [v0.4.4](https://github.com/mnemonikr/libsla/tree/v0.4.4)
 
 Minor update moving code out of symbolic-pcode workspace and into its own repository
 


### PR DESCRIPTION
This updates CHANGELOG.md to link to the tagged releases. This will improve navigation for older releases which only exist in the symbolic-pcode repository.