### PR TITLE
Rename LoadImage to InstructionLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let sleigh = GhidraSleigh::builder()
     .processor_spec(sleigh_config::processor_x86::PSPEC_X86_64)?
     .build(sleigh_config::processor_x86::SLA_X86_64)?;
 
-// The instruction reader is defined by the user and implements the LoadImage trait.
+// The instruction reader is defined by the user and implements the InstructionLoader trait.
 let instruction_reader = InstructionReader::new();
 
 // Instruction to decode from the reader.

--- a/src/tests/sleigh.rs
+++ b/src/tests/sleigh.rs
@@ -12,8 +12,8 @@ use crate::*;
 
 struct LoadImageImpl(Vec<u8>);
 
-impl LoadImage for LoadImageImpl {
-    fn instruction_bytes(&self, data: &VarnodeData) -> std::result::Result<Vec<u8>, String> {
+impl InstructionLoader for LoadImageImpl {
+    fn load_instruction_bytes(&self, data: &VarnodeData) -> std::result::Result<Vec<u8>, String> {
         let start: usize = data.address.offset.try_into().expect("invalid offset");
         if start >= self.0.len() {
             return Err("Requested fill outside image".to_string());


### PR DESCRIPTION
The `LoadImage` naming was borrowed directly from the API used within `libsla-sys`. This crate does not try to maintain 1:1 naming with the system APIs, and will diverge for improved clarity. In this case `InstructionLoader` is more clear.